### PR TITLE
Use ByteBuffer to convert from OpenCV Mat to PImage pixels array.

### DIFF
--- a/src/gab/opencv/OpenCV.java
+++ b/src/gab/opencv/OpenCV.java
@@ -1071,6 +1071,29 @@ public class OpenCV {
 
 
     /**
+     * Convert a 3 channel OpenCV Mat object into 
+     * pixels to be shoved into a 4 channel ARGB PImage's
+     * pixel array.
+     *
+     * @param m
+     *          A Mat you want converted
+     */
+    public int[] threeChanMatToARGBPixels(Mat m){
+        int pImageChannels = 4;
+        int numPixels = m.width()*m.height();
+        int[] intPixels = new int[numPixels];
+        Mat m2 = new Mat();
+  
+        // Assumes output PImage is ARGB.
+        Imgproc.cvtColor(m, m2, Imgproc.COLOR_RGB2RGBA);
+        byte[] matPixels = new byte[numPixels*pImageChannels];
+  
+        m2.get(0,0, matPixels);
+        ByteBuffer.wrap(matPixels).order(ByteOrder.LITTLE_ENDIAN).asIntBuffer().get(intPixels);
+        return intPixels;
+    }
+
+    /**
      * Convert a single channel, gray OpenCV Mat object into 
      * pixels to be shoved into a 4 channel ARGB PImage's
      * pixel array.
@@ -1131,11 +1154,7 @@ public class OpenCV {
 		  img.loadPixels();
 
 		  if(m.channels() == 3){
-			  byte[] matPixels = new byte[width*height*3];
-			  m.get(0,0, matPixels);
-			  for(int i = 0; i < m.width()*m.height()*3; i+=3){
-				  img.pixels[PApplet.floor(i/3)] = parent.color(matPixels[i+2]&0xFF, matPixels[i+1]&0xFF, matPixels[i]&0xFF);
-			  }
+              img.pixels = threeChanMatToARGBPixels(m);
 		  } else if(m.channels() == 1){
               img.pixels = grayMatToARGBPixels(m);
 		  } else if(m.channels() == 4){


### PR DESCRIPTION
I have noticed quite a good performance boost when I remove the for-loop in OpenCV#toPImage(). The use of ByteBuffers allows for bulk copying of the pixel data, but requires "ordering" of the bytes before converting to an int array (when channels > 1). One assumption that I've made is that the output PImage is in the ARGB format. I'm not sure if that is valid.

I am a n00b with Processing PImage pixel data, so I'm not sure I have been able to comprehensively test these changes. I did my best and have put some test sketches here: https://github.com/mudphone/opencv-processing/tree/to-pimage-with-buffers-test-sketches/examples/TESTS

There is a sketch for the single (gray), 3 (RGB), and 4 (RGBA) channel cases. I noticed a definite FPS increase when using this technique on machines with lower-powered CPUs (choppy FPS to 60 FPS). Even on a newer MBPro, I was able to see some improvement in the video sketches (50 FPS to >60 FPS).

Please let me know if there are any other cases you'd like me to test. Or, if I'm just plain missing some important use cases. I have only really used this for a single production sketch.

Credit for the idea to use ByteBuffer comes from Bryan Chung's blog: http://www.magicandlove.com/blog/2014/02/27/conversion-between-processing-pimage-and-opencv-cvmat/
