### PR TITLE
Region Flow Fix

### DIFF
--- a/src/gab/opencv/Flow.java
+++ b/src/gab/opencv/Flow.java
@@ -59,7 +59,7 @@ public class Flow {
 
 	public PVector getAverageFlowInRegion(int x, int y, int w, int h) {
 	    PVector total = getTotalFlowInRegion(x, y, w, h);
-	    return new PVector(total.x/(flow.width() * flow.height()), total.y/(flow.width()*flow.height()));
+	    return new PVector(total.x/(w*h), total.y/(w*h));
 	}
 
 	public PVector getTotalFlow() {


### PR DESCRIPTION
Fixing bug in average region flow, previously was dividing the total flow by the area of the entire cv object rather than the area of the region. Now uses the width and height passed into the function.