### PR TITLE
Add overload method to containsPoint

### DIFF
--- a/src/gab/opencv/Contour.java
+++ b/src/gab/opencv/Contour.java
@@ -52,6 +52,17 @@ public class Contour {
 	}
 	
 	/**
+	 * Check if the Contour contains a given PVector point. 
+	 * Useful when working with polygon approximations.
+	 * 
+	 * @param pt, a PVector
+	 * @return boolean 
+	 */
+	public boolean containsPoint(PVector pt) {
+		return containsPoint((int) pt.x, (int) pt.y);
+	}
+	
+	/**
 	 * Check if the Contour contains a given x-y point.
 	 * Particularly, useful for interaction via mouseX and mouseY.
 	 * 


### PR DESCRIPTION
A simple method that wraps a PVector instead of x, y ints.